### PR TITLE
Cj fix localdatetime deserializer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,6 @@ allprojects {
     }
 
     group = "net.besttoolbars"
-    version = "0.2.4"
+    version = "0.2.5"
 }
 

--- a/cj-connector/src/main/kotlin/net/besttoolbars/cj/json/CjLocalDateTimeDeserializer.kt
+++ b/cj-connector/src/main/kotlin/net/besttoolbars/cj/json/CjLocalDateTimeDeserializer.kt
@@ -6,20 +6,34 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.deser.std.StringDeserializer
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 
 class CjLocalDateTimeDeserializer : JsonDeserializer<LocalDateTime?>() {
-    override fun deserialize(p: JsonParser?, ctxt: DeserializationContext?): LocalDateTime? {
-        val result: String? = StringDeserializer.instance.deserialize(p, ctxt)
-        if (result.isNullOrBlank()) {
-            return null
+    override fun deserialize(p: JsonParser?, ctxt: DeserializationContext?): LocalDateTime? =
+        StringDeserializer.instance.deserialize(p, ctxt).let { raw ->
+            if (raw.isNullOrBlank()) null
+            else {
+                var result: LocalDateTime? = null
+                for (formatter in formatters) {
+                    try {
+                        result = LocalDateTime.parse(raw, formatter)
+                        break
+                    } catch (e: DateTimeParseException) {
+                        continue
+                    }
+                }
+                if (result == null)
+                    throw IllegalStateException("No patterns found for date: $raw")
+                result
+            }
         }
-        return LocalDateTime.parse(result,
-            formatter
-        )
-    }
 
     companion object {
-        private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.S")
+        private val formatters =
+            listOf(
+                "yyyy-MM-dd HH:mm:ss.S",
+                "yyyy-MM-dd HH:mm:ss.SSS"
+            ).map { DateTimeFormatter.ofPattern(it) }
     }
 }
 


### PR DESCRIPTION
Fix error
```
com.fasterxml.jackson.databind.JsonMappingException: Text '2024-07-30 11:30:00.176' could not be parsed, unparsed text found at index 21 (through reference chain: net.besttoolbars.cj.response.CjLinksResponse["links"]->net.besttoolbars.cj.response.CjLinks["link"]->java.util.ArrayList[23]->net.besttoolbars.cj.response.CjLink["promotion-end-date"])
```